### PR TITLE
Replace ci-task-runner with go-task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This file is auto-synced from product-os/jellyfish-config/sync/Dockerfile
 # and should only be edited there!
-FROM balena/open-balena-base:v11.2.0
+FROM resinci/jellyfish-test:v1.4.0
 
 WORKDIR /usr/src/jellyfish
 
@@ -11,4 +11,4 @@ RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc && \
 
 COPY . ./
 
-CMD /bin/bash -c "npx ci-task-runner run --config /usr/src/jellyfish/test/ci-tasks.yml"
+CMD /bin/bash -c "task test"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  test:
+    cmds:
+      - npm run integration

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@balena/ci-task-runner": "^0.3.3",
     "@balena/jellycheck": "^0.1.1",
     "@balena/jellyfish-action-library": "^14.0.7",
     "@balena/jellyfish-config": "^1.3.3",

--- a/test/ci-tasks.yml
+++ b/test/ci-tasks.yml
@@ -1,9 +1,0 @@
-tickTimeout: 5
-retryTimeout: 120
-attemptsDefault: 1
-tasks:
-  - name: 'integration-tests'
-    description: 'Integration Tests'
-    command: 'npm run integration'
-    cwd: '/usr/src/jellyfish'
-    required: true


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Replace `@balena/ci-task-runner` with [`go-task`](https://taskfile.dev/) for running tests in CI