### PR TITLE
Lookup contact and return link alongside survey contract

### DIFF
--- a/lib/integrations/typeform.ts
+++ b/lib/integrations/typeform.ts
@@ -1,4 +1,7 @@
-import type { Contract } from '@balena/jellyfish-types/build/core';
+import type {
+	Contract,
+	ContractData,
+} from '@balena/jellyfish-types/build/core';
 import type {
 	Integration,
 	IntegrationDefinition,
@@ -7,6 +10,7 @@ import type {
 } from '@balena/jellyfish-worker';
 import * as crypto from 'crypto';
 import * as _ from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 
 const SLUG = 'typeform';
 
@@ -40,74 +44,78 @@ export class TypeformIntegration implements Integration {
 			handle: this.options.defaultUser,
 		});
 		const formResponse = (event.data.payload as any).form_response;
-		const formId = formResponse.form_id;
-		const email =
-			!!formResponse.hidden && /\s/.test(formResponse.hidden.email)
-				? formResponse.hidden.email
-				: (formResponse.answers.find((el) => el.type === 'email') || {})
-						.email || null;
-		const responseId = formResponse.token;
-		const contractSlug = `user-feedback-${formId}-${responseId}`;
-		const formResponseMirrorId = `https://api.typeform.com/forms/${formId}/responses?included_response_ids=${responseId}`;
 		const username = /\s/.test(formResponse.hidden.user)
 			? null
 			: formResponse.hidden.user;
+
+		const email = /\s/.test(formResponse.hidden.email)
+			? formResponse.hidden.email
+			: (formResponse.answers.find((el) => el.type === 'email') || {}).email ||
+			  null;
+
+		const cardSlug =
+			`user-feedback-${formResponse.form_id}-${formResponse.token}`.toLowerCase();
+
 		const timestamp = new Date(formResponse.submitted_at).toISOString();
-		const questionsToProps = {
-			'How did you first hear about balenaCloud?':
-				'howDidYouFirstHearAboutBalenaCloud',
-			'How would you describe your role?': 'howWouldYouDescribeYourRole',
-			'Could you briefly describe your use case?':
-				'couldYouBrieflyDescribeYourUsecase',
-			'How has your experience been so far? What can we improve? We count on your honest feedback to make balenaCloud better.':
-				'howHasYourExperienceBeenSoFar',
-			'How likely are you to recommend balenaCloud to a friend or co-worker?':
-				'howLikelyAreYouToRecommendBalenaCloud',
-		};
-		const data = _.chain(
-			_.zip(formResponse.definition.fields, formResponse.answers),
-		)
-			.map((pair: any[]) => {
-				if (!Object.keys(questionsToProps).includes(pair[0].title)) {
-					// The only questions we currently support are the ones in questionsToProps keys.
-					// Any other question is ommited
-					return [];
-				}
-				for (const [title, props] of Object.entries(questionsToProps)) {
-					if (title === pair[0].title) {
-						return [props, pair[1][pair[1].type]];
-					}
-				}
-				return [];
-			})
-			.filter((item) => {
-				return _.size(item) > 0;
-			})
-			.fromPairs()
-			.assign({
-				mirrors: [formResponseMirrorId],
-				user: username,
-				status: 'open',
-				timestamp,
-				email,
-			})
-			.value();
-		return [
+
+		const surveyData = await formResponseToContractData(
+			username,
+			email,
+			timestamp,
+			formResponse,
+		);
+
+		const contactContract = await this.context.getContactByEmail(email);
+
+		const surveyContractId = uuidv4();
+		const surveyContractType = 'user-feedback@1.0.0';
+
+		const results = [
 			{
 				time: new Date(timestamp),
 				actor: adminActorId,
 				card: {
+					id: surveyContractId,
 					name: `Feedback from ${username || 'unknown user'}`,
-					type: 'user-feedback@1.0.0',
-					slug: contractSlug,
+					type: surveyContractType,
+					slug: cardSlug,
 					active: true,
 					tags: [],
 					requires: [],
 					capabilities: [],
-					data,
+					data: surveyData,
 				},
 			},
 		];
+
+		if (contactContract) {
+			results.push({
+				time: new Date(timestamp),
+				actor: adminActorId,
+				card: {
+					id: uuidv4(),
+					name: 'is attached to',
+					type: 'link@1.0.0',
+					slug: `link-${cardSlug}-is-attached-to-${contactContract.slug}`,
+					active: true,
+					tags: [],
+					requires: [],
+					capabilities: [],
+					data: {
+						inverseName: 'has attached element',
+						from: {
+							id: surveyContractId,
+							type: surveyContractType,
+						},
+						to: {
+							id: contactContract.id,
+							type: contactContract.type,
+						},
+					},
+				},
+			});
+		}
+		return results;
 	}
 }
 
@@ -125,4 +133,54 @@ export const typeformIntegrationDefinition: IntegrationDefinition = {
 			.digest('base64');
 		return signature === `sha256=${hash}`;
 	},
+};
+
+const formResponseToContractData = async (
+	username: string,
+	email: string | null,
+	timestamp: string,
+	formResponse: any,
+): Promise<ContractData> => {
+	const formId = formResponse.form_id;
+	const responseId = formResponse.token;
+	const formResponseMirrorId = `https://api.typeform.com/forms/${formId}/responses?included_response_ids=${responseId}`;
+
+	const questionsToProps = {
+		'How did you first hear about balenaCloud?':
+			'howDidYouFirstHearAboutBalenaCloud',
+		'How would you describe your role?': 'howWouldYouDescribeYourRole',
+		'Could you briefly describe your use case?':
+			'couldYouBrieflyDescribeYourUsecase',
+		'How has your experience been so far? What can we improve? We count on your honest feedback to make balenaCloud better.':
+			'howHasYourExperienceBeenSoFar',
+		'How likely are you to recommend balenaCloud to a friend or co-worker?':
+			'howLikelyAreYouToRecommendBalenaCloud',
+	};
+
+	return _.chain(_.zip(formResponse.definition.fields, formResponse.answers))
+		.map((pair: any[]) => {
+			if (!Object.keys(questionsToProps).includes(pair[0].title)) {
+				// The only questions we currently support are the ones in questionsToProps keys.
+				// Any other question is ommited
+				return [];
+			}
+			for (const [title, props] of Object.entries(questionsToProps)) {
+				if (title === pair[0].title) {
+					return [props, pair[1][pair[1].type]];
+				}
+			}
+			return [];
+		})
+		.filter((item) => {
+			return _.size(item) > 0;
+		})
+		.fromPairs()
+		.assign({
+			mirrors: [formResponseMirrorId],
+			user: username,
+			status: 'open',
+			timestamp,
+			email,
+		})
+		.value();
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@balena/jellyfish-worker": "^22.1.8",
     "autumndb": "^19.1.26",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@balena/jellyfish-config": "^2.0.6",
@@ -64,8 +65,7 @@
     "simple-git-hooks": "^2.7.0",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.22.15",
-    "typescript": "^4.6.3",
-    "uuid": "^8.3.2"
+    "typescript": "^4.6.3"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"


### PR DESCRIPTION
This PR adds a contact lookup whenever the `translate()` function is called. This tries to find an already registered contact whose email matches those present in the form hidden fields. If this contract is found, a link is created and returned together with the survey contract.

Depends on https://github.com/product-os/jellyfish-worker/pull/1368, which extends the context object with a function required for resolving the contact contract ID based on the provided email. Until this PR is merged, tests will fail.

Change-type: minor