### PR TITLE
Drop plugin-channels

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -20,10 +20,6 @@ export const typeformPlugin = (): PluginDefinition => {
 				slug: 'plugin-default',
 				version: '>=23.x',
 			},
-			{
-				slug: 'plugin-channels',
-				version: '>=2.x',
-			},
 		],
 	};
 };

--- a/package.json
+++ b/package.json
@@ -46,13 +46,12 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@balena/jellyfish-worker": "^30.0.23",
+    "@balena/jellyfish-worker": "^30.1.0",
     "autumndb": "^20.1.23",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@balena/jellyfish-plugin-channels": "^3.2.10",
     "@balena/jellyfish-plugin-default": "^27.8.19",
     "@balena/jellyfish-plugin-product-os": "^7.0.28",
     "@balena/jellyfish-types": "^2.0.5",

--- a/test/integration/typeform-translate.spec.ts
+++ b/test/integration/typeform-translate.spec.ts
@@ -1,4 +1,3 @@
-import { channelsPlugin } from '@balena/jellyfish-plugin-channels';
 import { defaultPlugin } from '@balena/jellyfish-plugin-default';
 import { productOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { testUtils as workerTestUtils } from '@balena/jellyfish-worker';
@@ -11,12 +10,7 @@ let ctx: workerTestUtils.TestContext;
 
 beforeAll(async () => {
 	ctx = await workerTestUtils.newContext({
-		plugins: [
-			defaultPlugin(),
-			productOsPlugin(),
-			channelsPlugin(),
-			typeformPlugin(),
-		],
+		plugins: [defaultPlugin(), productOsPlugin(), typeformPlugin()],
 	});
 	await workerTestUtils.translateBeforeAll(ctx);
 }, 10000);

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,13 +1,8 @@
-import { channelsPlugin } from '@balena/jellyfish-plugin-channels';
 import { defaultPlugin } from '@balena/jellyfish-plugin-default';
 import { PluginManager } from '@balena/jellyfish-worker';
 import { typeformPlugin } from '../../lib/index';
 
-const pluginManager = new PluginManager([
-	defaultPlugin(),
-	channelsPlugin(),
-	typeformPlugin(),
-]);
+const pluginManager = new PluginManager([defaultPlugin(), typeformPlugin()]);
 
 test('Expected contracts are loaded', () => {
 	const contracts = pluginManager.getCards();


### PR DESCRIPTION
Dropping plugin-channels as it has been merged into the worker

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>