### PR TITLE
Define/test env vars

### DIFF
--- a/lib/environment.ts
+++ b/lib/environment.ts
@@ -1,0 +1,18 @@
+/**
+ * This module uses the following environment variables:
+ * - INTEGRATION_TYPEFORM_SIGNATURE_KEY
+ *   - Typeform webhook signature key
+ *   - INTEGRATION_TYPEFORM_SIGNATURE_KEY="foobar"
+ */
+interface Environment {
+	signature: string;
+}
+
+export const defaults: Environment = {
+	signature: 'foobar',
+};
+
+export const environment: Environment = {
+	signature:
+		process.env['INTEGRATION_TYPEFORM_SIGNATURE_KEY'] || defaults.signature,
+};

--- a/lib/integrations/typeform.ts
+++ b/lib/integrations/typeform.ts
@@ -8,6 +8,7 @@ import type { Contract, ContractData } from 'autumndb';
 import * as crypto from 'crypto';
 import * as _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
+import { environment } from '../environment';
 
 const SLUG = 'typeform';
 
@@ -34,9 +35,6 @@ export class TypeformIntegration implements Integration {
 		event: Contract,
 		_options: { actor: string },
 	): Promise<SequenceItem[]> {
-		if (!this.options.token || !this.options.token.signature) {
-			return [];
-		}
 		const adminActorId = await this.context.getActorId({
 			handle: this.options.defaultUser,
 		});
@@ -120,14 +118,14 @@ export const typeformIntegrationDefinition: IntegrationDefinition = {
 	slug: SLUG,
 
 	initialize: async (options) => new TypeformIntegration(options),
-	isEventValid: (_logContext, token, rawEvent, headers) => {
+	isEventValid: (_logContext, _token, rawEvent, headers) => {
 		const signature = headers['typeform-signature'];
-		if (!signature || !token || !token.signature) {
+		if (!signature) {
 			return false;
 		}
 
 		const hash = crypto
-			.createHmac('sha256', token.signature)
+			.createHmac('sha256', environment.signature)
 			.update(rawEvent)
 			.digest('base64');
 		return signature === `sha256=${hash}`;

--- a/test/unit/environment/defaults.spec.ts
+++ b/test/unit/environment/defaults.spec.ts
@@ -1,0 +1,7 @@
+import { defaults, environment } from '../../../lib/environment';
+
+test('Default environment variable values are set', () => {
+	expect(environment).toEqual({
+		signature: defaults.signature,
+	});
+});

--- a/test/unit/environment/overrides.spec.ts
+++ b/test/unit/environment/overrides.spec.ts
@@ -1,0 +1,12 @@
+process.env.INTEGRATION_TYPEFORM_SIGNATURE_KEY = 'buzbaz';
+import { environment } from '../../../lib/environment';
+
+afterAll(() => {
+	delete process.env.INTEGRATION_TYPEFORM_SIGNATURE_KEY;
+});
+
+test('Can override environment variable defaults', () => {
+	expect(environment).toEqual({
+		signature: 'buzbaz',
+	});
+});


### PR DESCRIPTION
Define and test supported environment variables locally instead
of implicitly depending on jellyfish-environment.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>