### PR TITLE
CI: Use older flowzone tag

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   flowzone:
     name: Flowzone
-    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@v0.36.4
     secrets: inherit


### PR DESCRIPTION
Temporarily downgrading to older version of flowzone as CI is consistently failing due to problems in more recent version

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>